### PR TITLE
Get users to create /mingw64 and /mingw32 if needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,11 +65,19 @@
               If needed, close MSYS2, run it again from Start menu. Update the rest with:
               Update the package database and core system packages with:
               <pre>pacman -Syu</pre>
+            </li>
             <li>
               Again, if needed, close MSYS2, run it again from Start menu. Update the rest with:
               <pre>pacman -Su</pre>
               <img src="./6_msys2-update-system.png" alt="MSYS2 shell with pacman's output about system upgrade" />
               <br/><br/>
+            </li>
+            <li>
+              Normally you will want to install native WinAPI packages in addition to the core Cygwin-like packages of MSYS2.
+              Due to an <a href="https://github.com/msys2/msys2.github.io/issues/31">omission</a> in
+              <abbr title="msys2-x86_64-20160921.exe and msys2-i686-20160921.exe">the latest installer</abbr>,
+              this requres the roots to be created manually first.
+              <pre>mkdir -p /mingw64 /mingw32</pre>
             </li>
             <li>
               Now <strong>Pacman</strong> is fully committed to the Windows cause :)<br />


### PR DESCRIPTION
This is one approach. It may not be the best approach long-term, but at least the instructions will now deliver something you can install native packages into.