### PR TITLE
Fix wiki link location and a bullet list in "History" wiki page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ It features a package management system, Pacman, to provide easy installation of
 
 ## Support and Contact
 
-*   read our [wiki on GitHub](https://github.com/msys2/msys2/wiki)
+*   read our [wiki](https://www.msys2.org/wiki/Home/)
 *   browse our [package lists](https://packages.msys2.org/)
 *   search for and file [issues for msys2 packages on GitHub](https://github.com/msys2/msys2-packages/issues)
 *   search for and file [issues for mingw-w64 packages on GitHub](https://github.com/msys2/mingw-packages/issues)

--- a/docs/wiki/History.md
+++ b/docs/wiki/History.md
@@ -15,6 +15,7 @@ It is our hope that MSYS2 be viewed as a complementary off-shot of Cygwin (even 
 ## MinGW-w64
 
 MinGW is an abbreviation of *Minimalist GNU for Windows*. The idea of MinGW is to provide a development platform for building cross-platform applications on Windows. The important pieces are:
+
 * a set of FOSS Windows specific header files and import libraries which enable the use of the Windows API,
 * a supplementary library and a runtime that fill in some gaps.
 


### PR DESCRIPTION
Regarding the second of those two fixes, currently, what's meant to be the first bullet list on https://www.msys2.org/wiki/History/ (beginning right after "The important pieces are:") is not properly rendered. Adding a blank line before the first bulleted point should fix that.