### PR TITLE
ci: use 'branches-ignore' instead  of 'branches'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,8 @@ name: github pages
 on:
   workflow_dispatch:
   push:
-    branches:
-      - source
+    branches-ignore:
+      - master
 
 jobs:
   deploy:
@@ -34,6 +34,7 @@ jobs:
       - run: mkdocs build
 
       - name: Deploy
+        if: github.repository != 'msys2/msys2.github.io' || (github.event_name != 'pull_request' && github.ref == 'refs/heads/source')
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, forks cannot test feature branches easily, because CI ignores them. This PR changes the workflow for building all branches except `master`. In this repo, `source` is published only. In forks, any feature branch is published.