### PR TITLE
Replaced .xz with .zst

### DIFF
--- a/docs/docs/package-management.md
+++ b/docs/docs/package-management.md
@@ -56,7 +56,11 @@ The following command will remove a package (but not its dependencies nor any fi
 
 ## Installing a specific version of a package or a stand-alone packages
 
-Older (or pre-release) versions of packages can be installed directly from the package archive (`.tar.xz`). [The data store](http://repo.msys2.org/) for the repositories contains older versions of packages, but beware that you might need to recursively find correct versions of dependencies for the desired package. Once downloaded, the package can be installed like this:
+Older (or pre-release) versions of packages can be installed directly from the package archive (`.tar.zst` or `.tar.xz`). [The data store](http://repo.msys2.org/) for the repositories contains older versions of packages, but beware that you might need to recursively find correct versions of dependencies for the desired package. Once downloaded, the package can be installed like this:
+
+`pacman -U <packagefile.tar.zst>`
+
+or
 
 `pacman -U <packagefile.tar.xz>`
 

--- a/docs/wiki/Creating-Packages.md
+++ b/docs/wiki/Creating-Packages.md
@@ -46,7 +46,7 @@ The process happens in multiple phases:
 * `build()` - this function contains commands to run the build tool(s), e.g. `./configure` and `make`
 * `check()` - an optional step to check the build products by e.g. running the software's test suite
 * `package()` - this function is provided with a temporary directory, where it should put the final contents of the package using e.g. `make install`
-* tidy, archive and sign - the package contents are scanned for some issues, tidied up and packaged into the final `.tar.xz` with an optional signature in `.tar.xz.sig`
+* tidy, archive and sign - the package contents are scanned for some issues, tidied up and packaged into the final `.tar.zst` with an optional signature in `.tar.zst.sig`
 
 The makepkg tool takes arguments allowing you to turn off some phases or some checks. The typical usage is `makepkg -sCLf` for a full build and `makepkg -RdLf` for a "re-package". Re-packaging is useful when the process failed in `package()` and you don't want to run the long build part again. `makepkg-mingw` takes the same arguments.
 
@@ -59,14 +59,14 @@ An example of fetching the **msys** repository source, building and then install
     git clone "https://github.com/msys2/MSYS2-packages"
     cd MSYS2-packages/flex
     makepkg -sCLf
-    pacman -U flex-*.pkg.tar.xz
+    pacman -U flex-*.pkg.tar.zst
 
 An example of fetching the **mingw** repository source, building and then installing a package from it is:
 
     git clone "https://github.com/msys2/MINGW-packages"
     cd MINGW-packages/mingw-w64-python3
     makepkg-mingw -sCLf
-    pacman -U mingw-w64-*-python3-*-any.pkg.tar.xz
+    pacman -U mingw-w64-*-python3-*-any.pkg.tar.zst
 
 ## A new package from start to finish
 
@@ -154,7 +154,7 @@ Note that if you want to contribute, we'd appreciate it if you test your package
 
 ### Install package
 
-If the package build successfully, it's good to check its contents first before installing to see if it contains what you intended. When installing (using `pacman -U pkgname-pkgver-arch.tar.xz`), pacman checks for any filesystem conflicts and then places the package contents into your MSYS2 root as it would do with any other package. You can also remove the package using `pacman -R pkgname`.
+If the package build successfully, it's good to check its contents first before installing to see if it contains what you intended. When installing (using `pacman -U pkgname-pkgver-arch.tar.zst`), pacman checks for any filesystem conflicts and then places the package contents into your MSYS2 root as it would do with any other package. You can also remove the package using `pacman -R pkgname`.
 
 ### Test package
 

--- a/docs/wiki/MSYS2-reinstallation.md
+++ b/docs/wiki/MSYS2-reinstallation.md
@@ -1,11 +1,11 @@
 ---
 title: Re-installing MSYS2
-summary: When we release new installers and new base tar.xz packages
+summary: When we release new installers and new base tar.zst packages
 ---
 Introduction
 ------------
 
-When we release new installers and new base tar.xz packages, we'd appreciate it if people can help out by testing complete re-installs of their entire MSYS2. The procedure is safe as it is fully reversible. Also, if your system gets messed up, this procedure could help to get you running again.
+When we release new installers and new base tar.zst packages, we'd appreciate it if people can help out by testing complete re-installs of their entire MSYS2. The procedure is safe as it is fully reversible. Also, if your system gets messed up, this procedure could help to get you running again.
 
 Re-installing
 -------------


### PR DESCRIPTION
As pacman generates `.tar.zst` packages now, the documentation is somewhat out of date. I've replaced `.xz` with `.zst` in all corresponding places.

I've extended the documentation in `docs/docs/package-management.md` with `.tar.zst` rather than replacing it, as https://repo.msys2.org contains `.tar.xz` and `.tar.zst` files.