### PR TITLE
ci: mention the taskkill trick in case CI needs all processes to stop

### DIFF
--- a/web/docs/ci.md
+++ b/web/docs/ci.md
@@ -92,3 +92,13 @@ MSYS2 yourself.
    $env:MSYSTEM = 'MINGW64'  # Start a 64 bit Mingw environment
    C:\msys64\usr\bin\bash -lc './ci-build.sh'
    ```
+
+4) End all processes that might have been started by the MSYS2 update/setup
+
+In some cases CI systems will wait until all processes you have started have
+also ended, but the MSYS2 setup and update might spawn processes for gnupg etc.
+that will stay around in the background forever. To end them all you can run:
+
+  ```powershell
+  taskkill /F /FI "MODULES eq msys-2.0.dll"
+  ```


### PR DESCRIPTION
This affects the new Windows runners from gitlab-ci.