### PR TITLE
Fix broken link on Porting.md

### DIFF
--- a/web/wiki/Porting.md
+++ b/web/wiki/Porting.md
@@ -85,7 +85,9 @@ More 32/64 bit peculiarities
 ----------------------------
 
 Sorting out the stat thing by LRN:
-https://gnunet.org/sorting-out-stat-thing
+https://archive.li/IsgPq
+
+(Original URL - now down: `https://gnunet.org/sorting-out-stat-thing`)
 
 
 Calling conventions, stdcall, and autotools


### PR DESCRIPTION
The original URL (`https://gnunet.org/sorting-out-stat-thing`) appears to no longer be available, and I was unable to find a new URL on that domain, but did locate an archived copy.