### PR TITLE
Remove Ray's donation link

### DIFF
--- a/web/index.md
+++ b/web/index.md
@@ -200,7 +200,7 @@ Our main server is sponsored by [appfleet.com](https://appfleet.com)
 
 #### Ray Donnelly ([@mingwandroid](https://github.com/mingwandroid))
 
-* PayPal: [ray.donnelly@gmail.com](https://www.paypal.com/donate/?business=ray.donnelly%40gmail.com&item_name=Ray+Donnelly+MSYS2+development+donation&currency_code=GBP)
+See <https://www.msys2.org/news/#2021-04-21-rip-mingwandroid>
 
 #### Christoph Reiter ([@lazka](https://github.com/lazka))
 


### PR DESCRIPTION
It's not clear if any donations going there would end up somewhere useful,
so better remove them.

We're happy to revert this if that isn't the case though.