### PR TITLE
Update 'Who is using MSYS2?'

### DIFF
--- a/web/docs/who-is-using-msys2.md
+++ b/web/docs/who-is-using-msys2.md
@@ -3,18 +3,17 @@ title: Who Is Using MSYS2?
 ---
 # Who Is Using MSYS2?
 
-* [Git for Windows](https://gitforwindows.org/) is based on MSYS2
-* [The R Project](https://www.r-project.org/) build system [rtools40](https://cran.r-project.org/bin/windows/Rtools) is based on MSYS2 icw/ a custom repository of [mingw packages](https://github.com/r-windows/rtools-packages) (all statically linked).
-* [Quod Libet](https://quodlibet.readthedocs.io) uses MSYS2 for its Windows
-  build and for CI
-* [Inkscape](https://inkscape.org) uses MSYS2 for its Windows releases and for CI ([Documentation](https://wiki.inkscape.org/wiki/index.php?title=Compiling_Inkscape_on_Windows_with_MSYS2))
-* [Paperwork](https://openpaper.work) uses MSYS2 for its Windows releases and for CI ([Documentation](https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/blob/master/doc/devel.windows.markdown))
-* [Media-autobuild_suite](https://github.com/m-ab-s/media-autobuild_suite) uses MSYS2 for automatically building FFmpeg and other media related tools
-* [UrusStudio Installer](https://github.com/UrusTeam/urusstudio_installer) uses MSYS2 for building and running Urus Studio IDE and URUS System.
-* [KeePassXC](https://github.com/keepassxreboot/keepassxc) uses MSYS2 for building and running KeePassXC password manager.
 * [Gaphor](https://gaphor.org) uses MSYS2 for its Windows releases and for CI
-* [OpenModelica](https://openmodelica.org/) uses MSYS2 for building the OpenModelica tools and compiling the generated simulation code on Windows.
+* [Git for Windows](https://gitforwindows.org/) is based on MSYS2
+* [Quod Libet](https://quodlibet.readthedocs.io) uses MSYS2 for its Windows build and for CI
+* [Inkscape](https://inkscape.org) uses MSYS2 for its Windows releases and for CI ([Documentation](https://wiki.inkscape.org/wiki/index.php?title=Compiling_Inkscape_on_Windows_with_MSYS2))
+* [KeePassXC](https://github.com/keepassxreboot/keepassxc) uses MSYS2 for building and running KeePassXC password manager.
+* [Media-autobuild_suite](https://github.com/m-ab-s/media-autobuild_suite) uses MSYS2 for automatically building FFmpeg and other media related tools
 * [Nuwen's MinGW Build](https://nuwen.net/mingw.html) uses MSYS2 to build the files.
+* [OpenModelica](https://openmodelica.org/) uses MSYS2 for building the OpenModelica tools and compiling the generated simulation code on Windows.
+* [Paperwork](https://openpaper.work) uses MSYS2 for its Windows releases and for CI ([Documentation](https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/blob/master/doc/devel.windows.markdown))
+* [The R Project](https://www.r-project.org/) build system [rtools40](https://cran.r-project.org/bin/windows/Rtools) is based on MSYS2 icw/ a custom repository of [mingw packages](https://github.com/r-windows/rtools-packages) (all statically linked).
+* [UrusStudio Installer](https://github.com/UrusTeam/urusstudio_installer) uses MSYS2 for building and running Urus Studio IDE and URUS System.
 * [Webots](https://github.com/cyberbotics/webots) uses MSYS2 to build Webots on Windows and for CI.
 
 *Feel free to add your project to this list!*

--- a/web/docs/who-is-using-msys2.md
+++ b/web/docs/who-is-using-msys2.md
@@ -6,6 +6,16 @@ title: Who Is Using MSYS2?
 * [Gaphor](https://gaphor.org) uses MSYS2 for its Windows releases and for CI
 * [Git for Windows](https://gitforwindows.org/) is based on MSYS2
 * [Quod Libet](https://quodlibet.readthedocs.io) uses MSYS2 for its Windows build and for CI
+* [HDL/MINGW-packages](https://github.com/hdl/MINGW-packages) uses MSYS2 for building and testing open source Electronic Design Automation (EDA) tools.
+  * [ghdl/ghdl](https://github.com/ghdl/ghdl) uses MSYS2 for building, packaging and testing GHDL.
+    * [ghdl/setup-ghdl-ci](https://github.com/ghdl/setup-ghdl-ci) uses setup-msys2 for users to run GHDL on GitHub Actions' Windows environments.
+    * [ghdl/extended-tests](https://github.com/ghdl/extended-tests) uses setup-msys2 and setup-ghdl-ci for testing third-party projects with GHDL on GitHub Actions' Windows environments.
+  * [gtkwave/gtkwave](https://github.com/gtkwave/gtkwave) uses MSYS2 for building and packaging GTKWave.
+  * [steveicarus/iverilog](https://github.com/steveicarus/iverilog) uses MSYS2 for building, packaging and testing Icarus Verilog.
+  * [trabucayre/openFPGALoader](https://github.com/trabucayre/openFPGALoader) uses MSYS2 for building, packaging and testing openFPGALoader.
+  * [azonenberg/scopehal-apps](https://github.com/azonenberg/scopehal-apps) uses MSYS2 for building libscopehal, glscopeclient and other client applications for libscopehal.
+  * [Serial-Studio/Serial-Studio](https://github.com/Serial-Studio/Serial-Studio) uses MSYS2 for building and testing Serial Studio.
+  * [VUnit/vunit](https://github.com/VUnit/vunit) uses MSYS2 for testing VUnit.
 * [Inkscape](https://inkscape.org) uses MSYS2 for its Windows releases and for CI ([Documentation](https://wiki.inkscape.org/wiki/index.php?title=Compiling_Inkscape_on_Windows_with_MSYS2))
 * [KeePassXC](https://github.com/keepassxreboot/keepassxc) uses MSYS2 for building and running KeePassXC password manager.
 * [Media-autobuild_suite](https://github.com/m-ab-s/media-autobuild_suite) uses MSYS2 for automatically building FFmpeg and other media related tools


### PR DESCRIPTION
In the first commit, existing references are ordered alphabetically.

In the second commit, references to several projects using MSYS2 (setup-msys2) in their CI are added.
