### PR TITLE
packing-naming extended

### DIFF
--- a/web/docs/package-management.md
+++ b/web/docs/package-management.md
@@ -12,7 +12,7 @@ Packages in MSYS2 work like packages in popular Linux distributions. A package i
 
 There are 6 package repositories, the "classical" ones **msys2**, **mingw32**, and **mingw64** and the newer **ucrt64**, **clang32**, and **clang64**.
 The packages in **msys2** are named just like on a Linux distribution, the packages in the others are prefixed by either `mingw-w64-i686-` for 32-bit packages, or `mingw-w64-x86_64-` for 64-bit packages with a secondary prefix `clang` or `ucrt` where applicable.  
-For more details about those see ['Environments'](environments.md).
+For more details about those see ['Environments'](environments.md) and '[Package Naming'](package-naming.md).
 
 
 ## Finding a package

--- a/web/docs/package-naming.md
+++ b/web/docs/package-naming.md
@@ -1,6 +1,15 @@
-# Package Naming
+---
+title: Package Naming
+summary: The MSYS2 software distribution provides binary packages with for `pacman` using
+    prefixes according to the target environment.
+---
 
-|                                                          | Name           | Package prefix             |
+## Overview
+
+Tha following table lists the packages according to their environment, see ['Environments'](environments.md) for general information on these.
+When installing packages, see  ['Package Management'](package-,anagement.md), you'll commonly use the full name including the pacakge prefix as outlined below.
+
+|                                                          | Name [^1]      | Package prefix [^2]        |
 |----------------------------------------------------------|----------------|----------------------------|
 | ![msys](msys.png){: style="max-width:25px" }             | **MSYS**       | None                       |
 | ![mingw64](mingw64.png){: style="max-width:25px" }       | **MINGW64**    | `mingw-w64-x86_64-`        |
@@ -10,7 +19,10 @@
 | ![clang32](clang32.png){: style="max-width:25px" }       | **CLANG32**    | `mingw-w64-clang-i686-`    |
 | ![clangarm64](clangarm64.png){: style="max-width:25px" } | **CLANGARM64** | `mingw-w64-clang-aarch64-` |
 
-### Avoiding writing long package names
+[^1]: environment variable `MSYSTEM` 
+[^2]: environment variable `MINGW_PACKAGE_PREFIX`
+
+## Avoiding writing long package names
 
 Use `pacboy` to install **mingw** packages without having to type the long package names (install `pacboy` first using `pacman -S pactoys` if necessary).  Examples:
 


### PR DESCRIPTION
follow-up to 97544b5cb7dcd067f5a1f698e44c08dc08e49c72

* title and summary and use of level 2 headers
* copied env name notes from 454f891ade4d5311d91da505377fec9c3c064d55
* a bit of cross-referencing