### PR TITLE
Win32-OpenSSH instructions: replaced dead link with instructions

### DIFF
--- a/web/wiki/Setting-up-SSHd.md
+++ b/web/wiki/Setting-up-SSHd.md
@@ -1,5 +1,4 @@
-One can apparently connect the OpenSSHd build included with Windows to MSYS2.
-Diablo-D3 has written down the steps here: https://github.com/Diablo-D3/dotfiles#opensshd-on-windows
+One can connect to MSYS2 via Win32-OpenSSH by creating a batch file (e.g. C:\msys64\sshd_default_shell.cmd) containing `@C:\msys64\msys2_shell.cmd -defterm -here -no-start -mingw64` (you can change -mingw64 to the environment of your choice) and then setting the registry entry HKEY_LOCAL_MACHINE\SOFTWARE\OpenSSH\DefaultShell to the path of that batch file.
 
 MSYS2 can also use its own OpenSSHd.  Use the set-up script below.
 


### PR DESCRIPTION
The link refers to a page that no longer has instructions, so I added some instructions to the page itself. The methodology is basically the same as [were on](https://github.com/Diablo-D3/dotfiles/blob/87c8fc8e397c072914e48d5394b46a60262e541b/modules/os-win/sshd_msys2.bat) the linked page.

edit: although trying to use scp with this shell in use instead of cmd results in this error, so there may be some improvements possible:
```
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
```