### PR TITLE
fontFace and fontSize are deprecated terminal config options

### DIFF
--- a/web/docs/terminals.md
+++ b/web/docs/terminals.md
@@ -56,8 +56,11 @@ https://docs.microsoft.com/en-us/windows/terminal/customize-settings/profile-set
       "commandline": "C:/msys64/msys2_shell.cmd -defterm -here -no-start -mingw64",
       "startingDirectory": "C:/msys64/home/%USERNAME%",
       "icon": "C:/msys64/mingw64.ico",
-      "fontFace": "Lucida Console",
-      "fontSize": 9
+      "font": 
+      {
+        "face": "Lucida Console",
+        "size": 9
+      }
     },
     {
       "guid": "{2d51fdc4-a03b-4efe-81bc-722b7f6f3820}",
@@ -65,8 +68,11 @@ https://docs.microsoft.com/en-us/windows/terminal/customize-settings/profile-set
       "commandline": "C:/msys64/msys2_shell.cmd -defterm -here -no-start -mingw32",
       "startingDirectory": "C:/msys64/home/%USERNAME%",
       "icon": "C:/msys64/mingw32.ico",
-      "fontFace": "Lucida Console",
-      "fontSize": 9
+      "font": 
+      {
+        "face": "Lucida Console",
+        "size": 9
+      }
     },
     {
       "guid": "{71160544-14d8-4194-af25-d05feeac7233}",
@@ -74,8 +80,11 @@ https://docs.microsoft.com/en-us/windows/terminal/customize-settings/profile-set
       "commandline": "C:/msys64/msys2_shell.cmd -defterm -here -no-start -msys",
       "startingDirectory": "C:/msys64/home/%USERNAME%",
       "icon": "C:/msys64/msys2.ico",
-      "fontFace": "Lucida Console",
-      "fontSize": 9
+      "font": 
+      {
+        "face": "Lucida Console",
+        "size": 9
+      }
     },
     // ...
   ]


### PR DESCRIPTION
Convert deprecated fontFace and fontSize terminal config options to use the font object