### PR TITLE
fix: correct typo in installer filename

### DIFF
--- a/web/index.md
+++ b/web/index.md
@@ -37,7 +37,7 @@ MSYS2 and what for.
 
 ## Installation
 
-1. Download the installer: <a href="https://github.com/msys2/msys2-installer/releases/download/2024-07-27/msys2-x86_64-20240727.exe" class="button">msys2-x86_64-20240727.exe.exe</a>
+1. Download the installer: <a href="https://github.com/msys2/msys2-installer/releases/download/2024-07-27/msys2-x86_64-20240727.exe" class="button">msys2-x86_64-20240727.exe</a>
 
     <span style="opacity: 0.6; word-wrap: break-word;">(Optional) For more information on the installer, like command line options, or how to verify the checksum and signature of the installer, see the [installer guide](./docs/installer.md).</span>
 


### PR DESCRIPTION
Removed the extra ".exe" of the installer filename, which was first introduced in [this commit](https://github.com/msys2/msys2.github.io/commit/5b0bfd8d030d5acefc93ce886e0721d85a33d4a7). >_<