### PR TITLE
Add and sort common language translation options

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,9 @@ extra:
       - name: 한국어 (ko)
         link: https://www-msys2-org.translate.goog/?_x_tr_sl=en&_x_tr_tl=ko
         lang: ko
+      - name: 中文 (zh)
+        link: https://www-msys2-org.translate.goog/?_x_tr_sl=en&_x_tr_tl=zh
+        lang: zh
     social:
         - icon: 'fontawesome/brands/github'
           link: 'https://github.com/msys2'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,18 @@ extra_css:
 
 extra:
     alternate:
+      - name: Deutsch (de)
+        link: https://www-msys2-org.translate.goog/?_x_tr_sl=en&_x_tr_tl=de
+        lang: de
+      - name: Español (es)
+        link: https://www-msys2-org.translate.goog/?_x_tr_sl=en&_x_tr_tl=es
+        lang: es
+      - name: Français (fr)
+        link: https://www-msys2-org.translate.goog/?_x_tr_sl=en&_x_tr_tl=fr
+        lang: fr
+      - name: 日本语 (ja)
+        link: https://www-msys2-org.translate.goog/?_x_tr_sl=en&_x_tr_tl=ja
+        lang: ja
       - name: 한국어 (ko)
         link: https://www-msys2-org.translate.goog/?_x_tr_sl=en&_x_tr_tl=ko
         lang: ko


### PR DESCRIPTION
This PR updates the `mkdocs.yml` file to add and alphabetically sort common language translation options. The following languages have been added:
- German (Deutsch)
- Spanish (Español)
- French (Français)
- Japanese (日本语)
- Korean (한국어)
- Chinese (中文)

Please review and merge. Thank you!