### PR TITLE
ides-editors: remove `EDITOR` env workaround for Zed

### DIFF
--- a/web/docs/ides-editors.md
+++ b/web/docs/ides-editors.md
@@ -79,13 +79,9 @@ file
         "program": "cmd.exe",
         "args": ["/c", "C:\\msys64\\msys2_shell.cmd", "-defterm", "-here", "-no-start", "-ucrt64"]
       }
-    },
-    "env": {
-      "EDITOR": "zeditor.exe --wait"
     }
   }
 }
 ```
 
-Now UCRT64 shell will be opened if you press Ctrl + ~. EDITOR environment
-variable will be helpful, for example, when you use git from command line.
+Now UCRT64 shell will be opened if you press Ctrl + ~.


### PR DESCRIPTION
Zed 0.177.x added Git panel for all users. 98% of use cases are satisfied with it. so remove that workaround to less confuse users

_better to merge after Zed package update is available in the repo_ 