### PR TITLE
Replace outdated links to Git for Windows' wiki

### DIFF
--- a/web/docs/git.md
+++ b/web/docs/git.md
@@ -12,7 +12,7 @@ pacman -S git
 
 The [git-for-windows](https://github.com/git-for-windows) project maintains various patches on top of git itself as well as patches various MSYS2 packages to get the git test suite to pass on Windows and provide a complete and bug-free git experience. Our long term goal is to include their git build, but no one has started working on this yet.
 
-There exists a guide to install the official build into MSYS2: https://github.com/git-for-windows/git/wiki/Install-inside-MSYS2-proper but note that this setup is only supported on a best effort basis and any issues should be verified with the official git build before reporting them upstream.
+There exists a guide to install the official build into MSYS2: https://gitforwindows.org/install-inside-msys2-proper but note that this setup is only supported on a best effort basis and any issues should be verified with the official git build before reporting them upstream.
 
 ### Why are "gitk" and "git gui" not working in the MSYS environment?
 


### PR DESCRIPTION
Git for Windows' wiki pages were migrated in https://github.com/git-for-windows/git-for-windows.github.io/pull/59.