### PR TITLE
ides-editors: fix Zed config

### DIFF
--- a/web/docs/ides-editors.md
+++ b/web/docs/ides-editors.md
@@ -76,10 +76,11 @@ opened file. This is an example given for UCRT64 environment.
   "terminal": {
     "shell": {
       "with_arguments": {
-        "program": "cmd.exe",
-        "args": ["/c", "C:\\msys64\\msys2_shell.cmd", "-defterm", "-here", "-no-start", "-ucrt64"]
-      }
-    }
+        "title_override": "MSYS2 UCRT64 Shell",
+        "program": "powershell.exe",
+        "args": ["/c", "C:\\msys64\\msys2_shell.cmd", "-defterm", "-here", "-no-start", "-ucrt64"],
+      },
+    },
   }
 }
 ```


### PR DESCRIPTION
zed devs broke our configuration with strange way to get environment variables (see [upstream issue](https://github.com/zed-industries/zed/issues/47999)). fixing the config as pointed [here](https://github.com/zed-industries/zed/issues/47999#issuecomment-4188627617) works. huge thanks to @Wrench2710!